### PR TITLE
update gofuzz and set return values

### DIFF
--- a/address/fuzz.go
+++ b/address/fuzz.go
@@ -6,7 +6,7 @@ import (
 	dcrd_util "github.com/decred/dcrd/dcrutil/v3"
 )
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	{
 		addr, err := dcrd_util.DecodeAddress(string(input), dcrd_chaincfg.MainNetParams())
 		if err == nil {
@@ -25,4 +25,5 @@ func Fuzz(input []byte) {
 	dcrd_util.NewAddressSecpPubKey(input, dcrd_chaincfg.MainNetParams())
 	dcrd_util.NewAddressEdwardsPubKey(input, dcrd_chaincfg.MainNetParams())
 	dcrd_util.NewAddressSecSchnorrPubKey(input, dcrd_chaincfg.MainNetParams())
+	return 0
 }

--- a/amount/fuzz.go
+++ b/amount/fuzz.go
@@ -6,7 +6,7 @@ import (
 	dcrd_util "github.com/decred/dcrd/dcrutil/v3"
 )
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	buf := bytes.NewBuffer(input)
 	a1, err1 := binary.ReadVarint(buf)
 	a2, err2 := binary.ReadVarint(buf)
@@ -24,4 +24,5 @@ func Fuzz(input []byte) {
 			aAmnt.MulF64(b)
 		}
 	}
+	return 0
 }

--- a/base58/fuzz.go
+++ b/base58/fuzz.go
@@ -4,7 +4,8 @@ import (
 	dcrd_base58 "github.com/decred/base58"
 )
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	dcrd_base58.Decode(string(input))
 	dcrd_base58.Encode(input)
+	return 0
 }

--- a/block/fuzz.go
+++ b/block/fuzz.go
@@ -5,7 +5,7 @@ import (
 	dcrd_util "github.com/decred/dcrd/dcrutil/v3"
 )
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	block, err := dcrd_util.NewBlockFromBytes(input)
 	if err == nil {
 		txs := block.Transactions()
@@ -59,4 +59,5 @@ func Fuzz(input []byte) {
 			}
 		}
 	}
+	return 0
 }

--- a/chainhash/fuzz.go
+++ b/chainhash/fuzz.go
@@ -4,6 +4,7 @@ import (
 	dcrd_chainhash "github.com/decred/dcrd/chaincfg/chainhash"
 )
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	dcrd_chainhash.NewHashFromStr(string(input))
+	return 0
 }

--- a/edwards/fuzz.go
+++ b/edwards/fuzz.go
@@ -5,7 +5,7 @@ import (
 	dcrd_chainec "github.com/decred/dcrd/chaincfg/chainec"
 )
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	dcrd_chainec.Edwards.ParsePubKey(input)
 	dcrd_chainec.Edwards.PrivKeyFromBytes(input)
 	{
@@ -28,4 +28,5 @@ func Fuzz(input []byte) {
 	}
 	dcrd_chainec.Edwards.ParseDERSignature(input)
 	dcrd_chainec.Edwards.ParseSignature(input)
+	return 0
 }

--- a/secp256k1/fuzz.go
+++ b/secp256k1/fuzz.go
@@ -6,7 +6,7 @@ import (
 	dcrd_ecdsa "github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa"
 )
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	{
 		pk, err := dcrd_secp256k1.ParsePubKey(input)
 		if err == nil {
@@ -41,4 +41,5 @@ func Fuzz(input []byte) {
 	{
 		dcrd_ecdsa.ParseDERSignature(input)
 	}
+	return 0
 }

--- a/tx/fuzz.go
+++ b/tx/fuzz.go
@@ -5,7 +5,7 @@ import (
 	dcrd_txsort "github.com/decred/dcrd/dcrutil/v3/txsort"
 )
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	tx, err := dcrd_util.NewTxFromBytes(input)
 	if err == nil {
 		dcrd_util.NewTx(tx.MsgTx())
@@ -15,4 +15,5 @@ func Fuzz(input []byte) {
 		dcrd_txsort.Sort(msgTx)
 		dcrd_txsort.InPlaceSort(msgTx)
 	}
+	return 0
 }

--- a/txscript/fuzz.go
+++ b/txscript/fuzz.go
@@ -60,7 +60,7 @@ func dcrd_ExtractPKScriptAddrs(input []byte) {
 	dcrd_txscript.ExtractPkScriptAddrs(scriptVersion, input, dcrd_chaincfg.MainNetParams())
 }
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	if dcrd_txscript.IsMultisigSigScript(input) {
 		dcrd_txscript.MultisigRedeemScriptFromScriptSig(input)
 		/* Crashes 31-08-2018 dcrd_txscript.GetMultisigMandN(input) */
@@ -128,4 +128,5 @@ func Fuzz(input []byte) {
 			dcrd_txscript.PayToAddrScript(addr)
 		}
 	}
+	return 0
 }

--- a/wif/fuzz.go
+++ b/wif/fuzz.go
@@ -5,10 +5,11 @@ import (
 	dcrd_util "github.com/decred/dcrd/dcrutil/v3"
 )
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	wif, err := dcrd_util.DecodeWIF(string(input), dcrd_chaincfg.MainNetParams().PrivateKeyID)
 	if err == nil {
 		wif.String()
 		wif.PubKey()
 	}
+	return 0
 }

--- a/wire/fuzz.go
+++ b/wire/fuzz.go
@@ -151,12 +151,13 @@ func dcrdWire(pver uint32, net uint32, input []byte) {
 	dcrd_wire.WriteMessageN(&buf, msg, pver, dcrd_wire.CurrencyNet(net))
 }
 
-func Fuzz(input []byte) {
+func Fuzz(input []byte) int {
 	if len(input) < 8 {
-		return
+		return -1
 	}
 	pver := binary.BigEndian.Uint32(input[0:4])
 	net := binary.BigEndian.Uint32(input[4:8])
 	input = input[8:]
 	dcrdWire(pver, net, input)
+	return 0
 }


### PR DESCRIPTION
code needed some modification to work with latest gofuzz . 

also shows example of feedback in wire/fuzz.go   (which we should aim to add to all the fuzzing) 

return -1  = negative feedback (dont use these)
return 1 = positive feedback (use these)
return 0 = no feedback 

see https://github.com/dvyukov/go-fuzz#usage 